### PR TITLE
Update to Node 20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -127,7 +127,7 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   main: index.js
 
 branding:


### PR DESCRIPTION
It seems that getting rid of annoying annotation about deprecated Node requires just one line to be changed.

Fixes #25 

_P.S.
Until this gets merged or fixed in other ways, you can use forked action `inway/scout-action@node20` in workflows._