### PR TITLE
ci: update major tag on release

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -62,6 +62,8 @@ jobs:
     if:  startsWith(github.head_ref, 'release/v')
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.tagname.outputs.value }}
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -69,7 +71,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
       - name: Tag name
         uses: mad9000/actions-find-and-replace-string@2
         id: tagname
@@ -94,3 +95,12 @@ jobs:
           git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main --tags
           git tag -f ${{ steps.major.outputs.value }}
           git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main -f --tags
+
+  create_release:
+    needs:
+      - release
+    uses: ./.github/workflows/release.yml
+    permissions:
+      contents: write
+    with:
+      tag: ${{ needs.release.outputs.tag }}

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -36,16 +36,19 @@ jobs:
         uses: ./
         with:
           command: quickview
+          write-comment: false
       - name: TEST quickview
         uses: ./
         with:
           command: quickview
           image: docker/scout-demo-service:main
+          write-comment: false
       - name: TEST cves
         uses: ./
         with:
           command: cves
           image: docker/scout-demo-service:main
+          write-comment: false
       - name: TEST compare images
         uses: ./
         with:
@@ -53,6 +56,7 @@ jobs:
           image: registry://docker/scout-demo-service:main
           to: local://docker/scout-demo-service:fix
           exit-code: false
+          write-comment: false
 
   release:
     if:  startsWith(github.head_ref, 'release/v')

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -73,6 +73,13 @@ jobs:
           source: ${{ github.head_ref }}
           find: 'release/'
           replace: ''
+      - name: Major version
+        uses: ashley-taylor/regex-property-action@v1.3
+        id: major
+        with:
+          value: ${{ steps.tagname.outputs.value }}
+          regex: "\\.\\d+\\.\\d+$"
+          replacement: ''
       - name: Merge and Tag
         run: |
           git config --unset-all http.https://github.com/.extraheader
@@ -81,3 +88,5 @@ jobs:
           git merge --ff-only origin/${{ github.head_ref }}
           git tag ${{ steps.tagname.outputs.value }}
           git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main --tags
+          git tag -f ${{ steps.major.outputs.value }}
+          git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main -f --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,28 @@ on:
     tags:
       - 'v*.*.*'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: "The tag to release"
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_REF: ${{ github.event_name == 'push' && github.ref || inputs.tag }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_REF }}
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
+          tag_name: ${{ env.RELEASE_REF }}


### PR DESCRIPTION
For instance, if we are releasing the version `v1.2.3`, create the tag `v1` in addition to `v1.2.3`.
That way users can stick to `docker/scout-action@v1` and use the most recent released version.

fixes #28