### PR TITLE
docs: update `be a good guy` link

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,6 +1,6 @@
 # Support [![](https://isitmaintained.com/badge/resolution/docker/scout-action.svg)](https://isitmaintained.com/project/docker/scout-action)
 
-First, [be a good guy](https://github.com/kossnocorp/etiquette/blob/master/README.md).
+First, [be a good guy](https://github.com/kossnocorp/opensource.how/blob/classic/README.md).
 
 ## Reporting an issue
 


### PR DESCRIPTION
## Summary
I fixed the [be a good guy](https://github.com/kossnocorp/opensource.how/blob/classic/README.md) link which is not found in [SUPPORT.md](https://github.com/docker/scout-action/blob/main/.github/SUPPORT.md).

## Description
[opensource.how](https://github.com/kossnocorp/opensource.how/tree/main) changes repository name and the file structure.
So I switched the classic branch in order to refer to README.md.