### PR TITLE
Clarify action inputs and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ You can run one or multiple commands in the same GitHub Action run. Use a comma 
 
 | <!-- -->  | <!-- -->     | <!-- --> | <!-- -->                                                                                                                                                                                                                          |
 |:----------|:-------------|:---------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `command` | **required** | `string` | Single command to run or comma separated list of commands to run in order.<br/>Possible values:<br/><ul><li>`quickview`</li><li>`compare`</li><li>`cves`</li><li>`recommendations`</li><li>`sbom`</li><li>`environment`</li></ul> |
+| `command` | **required** | `string` | Single command to run or comma separated list of commands to run in order.<br/>Possible values:<br/><ul><li>`quickview`</li><li>`compare`</li><li>`cves`</li><li>`recommendations`</li><li>`sbom`</li><li>`environment`</li><li>`attestation-add`</li></ul> |
 
-The commands will be run in the order of the value, and will share the same parameters.
+The commands will be run in the order of the value, and will share the same parameters. If a command exits non-zero (for example when `exit-code` is `true`), the action step stops and the remaining commands are not executed.
 
 For instance, if you built an image and want to display a `quickview` as well as to `compare` it against the latest
 indexed one, set the action as following:
@@ -176,6 +176,7 @@ See [Prefix](#prefix) above about the available prefixes for the `to` argument.
 | `only-vex-affected`  | **optional** default is `false`                | `boolean` | Filter out CVEs that are marked not affected by a VEX statement                                           |
 | `vex-author`         | **optional** default is empty                  | `string`  | List of VEX statement authors to accept                                                                   |
 | `vex-location`       | **optional** default is empty                  | `string`  | File location of directory or file containing VEX statement                                               |
+| `ignore-suppressed`  | **optional** default is `false`                | `boolean` | Filter out CVEs affected by Scout suppressions                                                            |
 
 ## `sbom` Inputs
 
@@ -183,7 +184,7 @@ See [Prefix](#prefix) above about the available prefixes for the `to` argument.
 |:----------|:--------------------------------|:----------|:---------------------------------------------------------------------|
 | `format`  | **optional** default is `json`  | `string`  | Format of the SBOM to generate (`json`, `list`, `spdx`, `cyclonedx`) |
 | `output`  | **optional** default is empty   | `string`  | Path of the output file to write the SBOM                            |
-| `secrets` | **optional** default is `false` | `boolean` | Path of the output file to write the SBOM                            |
+| `secrets` | **optional** default is `false` | `boolean` | Enable secret scanning as part of SBOM indexing                      |
 
 ## `recommendations` Inputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -96,6 +96,9 @@ inputs:
   only-cisa-kev:
     required: false
     description: Filter to CVEs listed in the CISA Known Exploited Vulnerabilities catalog
+  ignore-suppressed:
+    required: false
+    description: Filter out CVEs affected by Scout suppressions
   exit-code:
     required: false
     description: Fail the action step if vulnerability changes are detected
@@ -106,6 +109,14 @@ inputs:
   sarif-file:
     required: false
     description: Write output to a SARIF file for further processing or upload into GitHub code scanning
+
+  # recommendations flags
+  only-refresh:
+    required: false
+    description: Only display base image refresh recommendations
+  only-update:
+    required: false
+    description: Only display base image update recommendations
 
   # sbom flags
   format:


### PR DESCRIPTION
## Summary
- align README command list and input descriptions with action inputs
- document ignore-suppressed and recommendations flags
- clarify multi-command behavior when a command exits non-zero

## Test plan
- not run (docs/metadata only)

Fixes #85
Fixes #70
Refs #86