### PR TITLE
ci(test): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     permissions:


### PR DESCRIPTION
The `test` workflow runs the scout-action tests. No GitHub API writes, so workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.